### PR TITLE
Update network cost calculation process

### DIFF
--- a/src/main/java/org/matsim/project/prebookingStudy/jsprit/utils/FreeSpeedTravelTimeWithRoundingUp.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/jsprit/utils/FreeSpeedTravelTimeWithRoundingUp.java
@@ -1,0 +1,14 @@
+package org.matsim.project.prebookingStudy.jsprit.utils;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.vehicles.Vehicle;
+
+public class FreeSpeedTravelTimeWithRoundingUp implements TravelTime {
+    @Override
+    public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
+        double freeSpeedTravelTime = link.getLength() / link.getFreespeed(time);
+        return Math.ceil(freeSpeedTravelTime);
+    }
+}


### PR DESCRIPTION
- Using rounded up travel time for each link for a better estimation of the travel time
- Add the DRT stop duration in the cost calculator. Default drt stop duration is 60 seconds (same as in MATSim). The DRT stop time is now included in the router, so that it matches the setup in MATSim: fix stopping duration regardless of number of boarding/alighting customer.
 
Attention: When analyzing the total travel time and on-board travel time of the customer in Jsprit solution, the DRT stop duration should be substracted. 