### PR TITLE
Solving the departure time and location issue

### DIFF
--- a/src/main/java/org/matsim/playground/testingScript/TestingNode.java
+++ b/src/main/java/org/matsim/playground/testingScript/TestingNode.java
@@ -1,0 +1,33 @@
+package org.matsim.playground.testingScript;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+
+public class TestingNode {
+    public static void main(String[] args) {
+        Network network1 = NetworkUtils.readNetwork("/Users/luchengqi/Documents/MATSimScenarios/Vulkaneifel/drt-prebooking-study/scenarios/input/vulkaneifel-v1.0-network.xml.gz");
+        Coord coord = new Coord(333509.84287451406, 5578818.032624912);
+        Link link = NetworkUtils.getNearestLink(network1, coord);
+        System.out.println(link.getId().toString());
+
+        Link linkExact = NetworkUtils.getNearestLinkExactly(network1, coord);
+        System.out.println("Exact link:" + linkExact.getId().toString());
+
+        Coord coord2 = linkExact.getToNode().getCoord();
+        Link link2 = NetworkUtils.getNearestLinkExactly(network1, coord2);
+        System.out.println(link2.getId().toString());
+
+        Config config = ConfigUtils.loadConfig("/Users/luchengqi/Documents/MATSimScenarios/Vulkaneifel/drt-prebooking-study/scenarios/input/vulkaneifel-v1.0-school-children.config.xml");
+        Scenario scenario = ScenarioUtils.loadScenario(config);
+        Network network2 = scenario.getNetwork();
+        Link link3 = NetworkUtils.getNearestLink(network2, coord);
+        System.out.println(link3.getId().toString());
+    }
+
+}


### PR DESCRIPTION
The NetworkUtils.getNearestLink does not return the same link all the time for the same coord (among different runs). This causes the difference in estimated walking time (access walk).

- Now the link is added to the activity, such that the same link will be used to create the facility all the time.
- The walking time is actually rounded down in the teleporting mode (the double value is cast into int), the walking time calculation is therefore updated here.

With this fix, all the latest arrival time is correct now.