### PR TITLE
Adding PT baseline

### DIFF
--- a/src/main/java/org/matsim/project/prebookingStudy/analysis/ptBenchmark/PrepareNetworkWithPt.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/analysis/ptBenchmark/PrepareNetworkWithPt.java
@@ -1,0 +1,45 @@
+package org.matsim.project.prebookingStudy.analysis.ptBenchmark;
+
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.network.NetworkUtils;
+
+public class PrepareNetworkWithPt {
+    public static void main(String[] args) {
+        String networkPath;
+        String ptNetworkPath;
+        String outputPath;
+        if (args.length != 0) {
+            networkPath = args[0];
+            ptNetworkPath = args[1];
+            outputPath = args[3];
+        } else {
+            networkPath = "/Users/luchengqi/Documents/MATSimScenarios/Vulkaneifel/drt-prebooking-study/scenarios/input/vulkaneifel-v1.0-network.xml.gz";
+            ptNetworkPath = "/Users/luchengqi/Documents/MATSimScenarios/Vulkaneifel/drt-prebooking-study/scenarios/input/pt-files/optimizedNetwork.xml.gz";
+            outputPath = "/Users/luchengqi/Documents/MATSimScenarios/Vulkaneifel/drt-prebooking-study/scenarios/input/pt-files/network-with-pt.xml.gz";
+        }
+
+        Network network = NetworkUtils.readNetwork(networkPath);
+        Network ptNetwork = NetworkUtils.readNetwork(ptNetworkPath);
+        modifyNetwork(network, ptNetwork);
+        NetworkUtils.writeNetwork(network, outputPath);
+    }
+
+    private static void modifyNetwork(Network network, Network ptNetwork) {
+        for (Link ptLink : ptNetwork.getLinks().values()) {
+            if (ptLink.getAllowedModes().contains(TransportMode.pt)) {
+                Node fromNode = ptLink.getFromNode();
+                Node toNode = ptLink.getToNode();
+                if (!network.getNodes().containsValue(fromNode)) {
+                    network.addNode(fromNode);
+                }
+                if (!network.getNodes().containsValue(toNode)) {
+                    network.addNode(toNode);
+                }
+                network.addLink(ptLink);
+            }
+        }
+    }
+}

--- a/src/main/java/org/matsim/project/prebookingStudy/analysis/ptBenchmark/RunPtScenario.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/analysis/ptBenchmark/RunPtScenario.java
@@ -1,0 +1,69 @@
+package org.matsim.project.prebookingStudy.analysis.ptBenchmark;
+
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorModule;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.application.MATSimAppCommand;
+import org.matsim.application.analysis.DefaultAnalysisMainModeIdentifier;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.router.AnalysisMainModeIdentifier;
+import org.matsim.core.scenario.ScenarioUtils;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "run-pt-baseline",
+        description = "run pt baseline"
+)
+public class RunPtScenario implements MATSimAppCommand {
+    @CommandLine.Option(names = "--config", description = "path to config file", required = true)
+    private static String configPath;
+
+    @CommandLine.Option(names = "--output", description = "path to config file", required = true)
+    private static String outputDirectory;
+
+    public static void main(String[] args) {
+        new RunPtScenario().execute(args);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        Config config = ConfigUtils.loadConfig(configPath);
+        config.controler().setOutputDirectory(outputDirectory);
+        config.planCalcScore().setWriteExperiencedPlans(true);
+        config.controler().setLastIteration(1);
+
+        Scenario scenario = ScenarioUtils.loadScenario(config);
+        modifyPopulation(scenario.getPopulation());
+
+        Controler controler = new Controler(scenario);
+        controler.addOverridingModule(new AbstractModule() {
+            @Override
+            public void install() {
+                install(new SwissRailRaptorModule());
+                bind(AnalysisMainModeIdentifier.class).to(DefaultAnalysisMainModeIdentifier.class);
+            }
+        });
+        controler.run();
+        return 0;
+    }
+
+    /**
+     * Set the mode of every trip to PT
+     */
+    private static void modifyPopulation(Population population) {
+        for (Person person : population.getPersons().values()) {
+            for (PlanElement pe : person.getSelectedPlan().getPlanElements()) {
+                if (pe instanceof Leg) {
+                    ((Leg) pe).setMode(TransportMode.pt);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prof. Nagel suggests that we should also compare our reuslts to the conventional PT service. This script is to run the PT simualtion. 

In current implmentation, all the student will use the PT mode (when no feasible PT trip is found, they will walk). The output can show the travel time of the PT trips.

In the next phase, we can try to compute PT route without actually run the simualtion. 