### PR TITLE
Add post analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<description>A repository for pre-booking study project</description>
 
 	<properties>
-		<matsim.version>15.0-PR1970</matsim.version>
+		<matsim.version>15.0-PR1972</matsim.version>
 <!--		<matsim.version>15.0-SNAPSHOT</matsim.version>-->
 		<jsprit.version>1.8</jsprit.version>
 	</properties>

--- a/src/main/java/org/matsim/project/prebookingStudy/analysis/RunPostAnalysis.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/analysis/RunPostAnalysis.java
@@ -1,0 +1,49 @@
+package org.matsim.project.prebookingStudy.analysis;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.matsim.application.MATSimAppCommand;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Path;
+import java.util.Objects;
+
+@CommandLine.Command(
+        name = "post-analysis",
+        description = "Run analysis for finsihed runs"
+)
+public class RunPostAnalysis implements MATSimAppCommand {
+    @CommandLine.Option(names = "--directory", description = "path to root output directory", required = true)
+    private Path directory;
+
+    @CommandLine.Option(names = "--departure-delay-analysis", description = "enable departure delay analysis", defaultValue = "false")
+    private boolean includeDepartureDelayAnalysis;
+
+    public static void main(String[] args) {
+        new RunPostAnalysis().execute(args);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        File rootDirectory = new File(directory.toString());
+        SchoolTripsAnalysis schoolTripsAnalysis = new SchoolTripsAnalysis();
+        schoolTripsAnalysis.setIncludeDepartureDelayAnalysis(includeDepartureDelayAnalysis);
+
+        CSVPrinter tsvWriter = new CSVPrinter(new FileWriter(rootDirectory.getAbsolutePath() + "/result-summary.tsv"), CSVFormat.TDF);
+        tsvWriter.printRecord(SchoolTripsAnalysis.TITLE_ROW_KPI);
+        tsvWriter.close();
+
+        for (File folder: Objects.requireNonNull(rootDirectory.listFiles())) {
+            if (folder.isDirectory()){
+                schoolTripsAnalysis.analyze(folder.toPath());
+                CSVPrinter resultsWriter = new CSVPrinter(new FileWriter(rootDirectory.getAbsolutePath() + "/result-summary.tsv", true), CSVFormat.TDF);
+                resultsWriter.printRecord(schoolTripsAnalysis.getOutputKPIRow());
+                resultsWriter.close();
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/org/matsim/project/prebookingStudy/analysis/SchoolTripsAnalysis.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/analysis/SchoolTripsAnalysis.java
@@ -12,6 +12,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.contrib.common.util.DistanceUtils;
+import org.matsim.contrib.drt.extension.preplanned.optimizer.WaitForStopTask;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.drt.util.DrtEventsReaders;
@@ -98,11 +99,10 @@ public class SchoolTripsAnalysis implements MATSimAppCommand {
 
         // Analyze departure delay
         DepartureDelayAnalysis departureDelayAnalysis = new DepartureDelayAnalysis();
-        //TODO this is a temporary solution. Wait until the "Wait for stop" events have been added to the activity types
         if (includeDepartureDelayAnalysis){
             EventsManager eventsManager = EventsUtils.createEventsManager();
             eventsManager.addHandler(departureDelayAnalysis);
-            MatsimEventsReader eventsReader = DrtEventsReaders.createEventsReader(eventsManager);
+            MatsimEventsReader eventsReader = DrtEventsReaders.createEventsReader(eventsManager, WaitForStopTask.TYPE);
             eventsReader.readFile(eventPath.toString());
         }
         Map<Id<Person>, Double> initialDepartureMap = departureDelayAnalysis.getInitialScheduledPickupTimeMap();

--- a/src/main/java/org/matsim/project/prebookingStudy/run/RunJspritExperiment.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/run/RunJspritExperiment.java
@@ -17,7 +17,6 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
-import org.matsim.core.network.NetworkUtils;
 import org.matsim.project.prebookingStudy.analysis.SchoolTripsAnalysis;
 import org.matsim.project.prebookingStudy.jsprit.PreplannedSchedulesCalculator;
 import picocli.CommandLine;

--- a/src/main/java/org/matsim/project/prebookingStudy/run/RunMATSimBenchmark.java
+++ b/src/main/java/org/matsim/project/prebookingStudy/run/RunMATSimBenchmark.java
@@ -1,35 +1,29 @@
 package org.matsim.project.prebookingStudy.run;
 
-import com.google.inject.Inject;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.io.FileUtils;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.population.Population;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.analysis.DefaultAnalysisMainModeIdentifier;
 import org.matsim.contrib.drt.analysis.afterSimAnalysis.DrtVehicleStoppingTaskWriter;
-import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRoute;
 import org.matsim.contrib.drt.routing.DrtRouteFactory;
-import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtConfigs;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtModule;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarkTravelTimeModule;
 import org.matsim.contrib.dvrp.router.DefaultMainLegRouter;
-import org.matsim.contrib.dvrp.run.*;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.router.AnalysisMainModeIdentifier;
-import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
-import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
-import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.project.prebookingStudy.analysis.SchoolTripsAnalysis;
 import org.matsim.project.prebookingStudy.run.rebalancing.RuralScenarioRebalancingTCModule;
@@ -41,7 +35,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.function.Function;
 
 @CommandLine.Command(
         name = "run",


### PR DESCRIPTION
The post analysis run script enables us to re-run analysis without running the simulation again. This is particularly useful when we decide to add some analysis (e.g. departure delay) or modify some analysis element. 